### PR TITLE
Typo instruction -> register

### DIFF
--- a/modules/01-intro_assembly/assembly/readme.md
+++ b/modules/01-intro_assembly/assembly/readme.md
@@ -216,7 +216,7 @@ The lea instruction calculates the address of the second operand, and moves that
 lea rdi, [rbx+0x10]
 ```
 
-This will move the address of `rbx+0x10`  into the `rdi` instruction.
+This will move the address `rbx+0x10` into the `rdi` register.
 
 #### add
 This just adds the two values together, and stores the sum in the first argument. For instance:


### PR DESCRIPTION
The description of the LEA instruction said that it would compute the result of the address and store it in the `rdi` _instruction_, where it should have said _register_. I also took away the `of` because it reads better. 