### PR TITLE
House of spirit explanation diagram offset fixes

### DIFF
--- a/modules/39-house_of_spirit/house_spirit_exp/house_spirit_exp.c
+++ b/modules/39-house_of_spirit/house_spirit_exp/house_spirit_exp.c
@@ -40,11 +40,11 @@ int main(void)
 	+-------+---------------------+------+
 	| 0x10: | Chunk # 0 content   | 0x00 |
 	+-------+---------------------+------+
-	| 0x70: | Chunk # 1 prev size | 0x00 |
+	| 0x60: | Chunk # 1 prev size | 0x00 |
 	+-------+---------------------+------+
-	| 0x78: | Chunk # 1 size      | 0x40 |
+	| 0x68: | Chunk # 1 size      | 0x40 |
 	+-------+---------------------+------+
-	| 0x80: | Chunk # 1 content   | 0x00 |
+	| 0x70: | Chunk # 1 content   | 0x00 |
 	+-------+---------------------+------+
 
 	for what we are doing the prev size values don't matter too much

--- a/modules/39-house_of_spirit/house_spirit_exp/readme.md
+++ b/modules/39-house_of_spirit/house_spirit_exp/readme.md
@@ -48,11 +48,11 @@ int main(void)
 	+-------+---------------------+------+
 	| 0x10: | Chunk # 0 content   | 0x00 |
 	+-------+---------------------+------+
-	| 0x70: | Chunk # 1 prev size | 0x00 |
+	| 0x60: | Chunk # 1 prev size | 0x00 |
 	+-------+---------------------+------+
-	| 0x78: | Chunk # 1 size      | 0x40 |
+	| 0x68: | Chunk # 1 size      | 0x40 |
 	+-------+---------------------+------+
-	| 0x80: | Chunk # 1 content   | 0x00 |
+	| 0x70: | Chunk # 1 content   | 0x00 |
 	+-------+---------------------+------+
 
 	for what we are doing the prev size values don't matter too much


### PR DESCRIPTION
There seems to some typos in the diagram. Based on the explanation and provided code (i.e `array[13]=0x40`, and the size of the first chunk being 0x60, it seems like the offsets should be what is changed in this PR instead